### PR TITLE
Remove debug instructions from sign-in panel

### DIFF
--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -34,7 +34,7 @@ export function AppSidebar() {
     <Sidebar className="hidden border-r sm:flex">
       <SidebarContent>
         <SidebarHeader>
-          <a href="#" className="flex items-center gap-2 font-semibold">
+          <a href="/" className="flex items-center gap-2 font-semibold">
             <Package2 className="h-6 w-6" />
             <span>Ledger</span>
           </a>
@@ -45,7 +45,7 @@ export function AppSidebar() {
               <TooltipTrigger asChild>
                 <SidebarMenuItem>
                   <SidebarMenuButton asChild isActive>
-                    <a href="#">
+                    <a href="/">
                       <Home className="h-5 w-5" />
                       <span className="sr-only">Dashboard</span>
                     </a>

--- a/components/auth-guard.tsx
+++ b/components/auth-guard.tsx
@@ -119,13 +119,6 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
                 )}
               </Button>
             </form>
-
-            <div className="mt-4 p-3 bg-muted rounded-md text-sm text-muted-foreground">
-              <p className="font-medium mb-1">Debug Steps:</p>
-              <p>1. Check browser console for detailed errors</p>
-              <p>2. Verify Supabase URL/Key in environment</p>
-              <p>3. Check Supabase auth settings</p>
-            </div>
           </CardContent>
         </Card>
       </div>

--- a/components/auth-provider.tsx
+++ b/components/auth-provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { User } from "@supabase/supabase-js";
+import type { AuthResponse, User } from "@supabase/supabase-js";
 import type React from "react";
 import { createContext, useContext, useEffect, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
@@ -8,10 +8,7 @@ import { createClient } from "@/lib/supabase/client";
 interface AuthContextType {
   user: User | null;
   loading: boolean;
-  signIn: (
-    email: string,
-    password: string
-  ) => Promise<{ data: any; error: any }>;
+  signIn: (email: string, password: string) => Promise<AuthResponse>;
   signOut: () => Promise<void>;
 }
 
@@ -55,7 +52,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange(async (event, session) => {
+    } = supabase.auth.onAuthStateChange(async (_event, session) => {
       setUser(session?.user ?? null);
       setLoading(false);
     });

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { Search, Upload } from "lucide-react";
 import { useEffect, useState } from "react";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -28,8 +27,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-
 import { createClient } from "@/lib/supabase/client";
+import type { ExpenseDatabaseRow } from "@/lib/types/expense";
 import { ExpensesTable } from "./expenses-table";
 import type { Expense } from "./expenses-table-columns";
 import { UploadDialog } from "./upload-dialog";
@@ -135,7 +134,7 @@ export function Dashboard() {
 
     // Fetch existing expenses first
     const fetchExpenses = async () => {
-      const { data, error } = await supabase
+      const { data } = await supabase
         .from("expenses")
         .select("*")
         .order("date", { ascending: false });
@@ -171,8 +170,8 @@ export function Dashboard() {
           table: "expenses",
         },
         (payload) => {
-          const newExpense = payload.new as any;
-          const formattedExpense = {
+          const newExpense = payload.new as ExpenseDatabaseRow;
+          const formattedExpense: Expense = {
             id: newExpense.id,
             description: newExpense.description,
             merchant: newExpense.merchant || "",

--- a/components/expenses-table.tsx
+++ b/components/expenses-table.tsx
@@ -51,7 +51,7 @@ export function ExpensesTable({
       columnFilters,
       globalFilter,
     },
-    globalFilterFn: (row, columnId, filterValue) => {
+    globalFilterFn: (row, _columnId, filterValue) => {
       const searchValue = filterValue.toLowerCase();
       const description = row.getValue("description") as string;
       const category = row.getValue("category") as string;

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -4,7 +4,6 @@ import {
   ThemeProvider as NextThemesProvider,
   type ThemeProviderProps,
 } from "next-themes";
-import * as React from "react";
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
   return <NextThemesProvider {...props}>{children}</NextThemesProvider>;

--- a/components/ui/pagination.tsx
+++ b/components/ui/pagination.tsx
@@ -5,7 +5,6 @@ import { cn } from "@/lib/utils";
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
   <nav
-    role="navigation"
     aria-label="pagination"
     className={cn("mx-auto flex w-full justify-center", className)}
     {...props}

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -90,7 +90,7 @@ const SidebarProvider = React.forwardRef<
       return isMobile
         ? setOpenMobile((open) => !open)
         : setOpen((open) => !open);
-    }, [isMobile, setOpen, setOpenMobile]);
+    }, [isMobile, setOpen]);
 
     React.useEffect(() => {
       const handleKeyDown = (event: KeyboardEvent) => {
@@ -119,7 +119,7 @@ const SidebarProvider = React.forwardRef<
         setOpenMobile,
         toggleSidebar,
       }),
-      [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
+      [state, open, setOpen, isMobile, openMobile, toggleSidebar]
     );
 
     return (

--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,

--- a/lib/types/expense.ts
+++ b/lib/types/expense.ts
@@ -69,3 +69,22 @@ export interface UploadResult {
  * Statement processing status
  */
 export type StatementStatus = "processing" | "completed" | "failed";
+
+/**
+ * Expense as returned from database queries (Supabase realtime payload)
+ */
+export interface ExpenseDatabaseRow {
+  id: string;
+  description: string;
+  merchant: string | null;
+  category: string;
+  amount_sgd: string;
+  date: string;
+  original_amount: string | null;
+  original_currency: string | null;
+  currency: string;
+  statement_id?: string;
+  user_id?: string;
+  line_hash?: string;
+  created_at?: string;
+}


### PR DESCRIPTION
## Summary
- Removes debug instructions section from the sign-in panel to clean up the UI
- Fixes various linting issues throughout the codebase
- Closes #1

## Changes
- **AuthGuard component**: Removed the debug steps section (lines 123-128)
- **Type improvements**: 
  - Fixed TypeScript `any` types in auth-provider.tsx
  - Added `ExpenseDatabaseRow` interface for Supabase realtime payloads
- **Code quality fixes**:
  - Removed unused imports and parameters
  - Fixed React hook dependencies
  - Updated sidebar navigation links to use proper hrefs

## Test plan
- [x] Sign-in page displays without debug instructions
- [x] Sign-in functionality still works correctly
- [x] All linting checks pass (except for third-party UI components and intentional patterns)

🤖 Generated with [Claude Code](https://claude.ai/code)